### PR TITLE
Simplify Event Loop

### DIFF
--- a/feedbacks.js
+++ b/feedbacks.js
@@ -1,6 +1,6 @@
 import { combineRgb } from '@companion-module/base'
 
-export function getFeedbacks() {
+export default function(self) {
 	const feedbacks = {}
 
 	const ColorWhite = combineRgb(255, 255, 255)
@@ -25,14 +25,15 @@ export function getFeedbacks() {
 				min: 1,
 			},
 		],
-		callback: (feedback) => {
-			let portInfo = this.switch?.poePortConfig?.find(({ portid }) => portid === feedback.options.port)
-
-			if (portInfo) {
-				return portInfo.enable
+		callback: async (feedback) => {
+			if(self.poe_status && self.poe_status.has(feedback.options.port)) {
+				const port = self.poe_status.get_port_configuration(feedback.options.port)
+				return port.enable
 			}
-		},
-	}
+
+			return undefined
+		}
+	},
 	feedbacks['linkStatus'] = {
 		type: 'boolean',
 		name: 'Link Status',
@@ -49,14 +50,15 @@ export function getFeedbacks() {
 				min: 1,
 			},
 		],
-		callback: (feedback) => {
-			let portInfo = this.switch?.switchStatsPort?.find(({ portId }) => portId === feedback.options.port)
-
-			if (portInfo) {
-				return portInfo.status === 0 ? true : false
+		callback: async (feedback) => {
+			if(self.port_stats && self.port_stats.has(feedback.options.port)) {
+				const port = self.port_stats.get_port_stats(feedback.options.port)
+				return port.status === 0
 			}
-		},
+
+			return undefined
+		}
 	}
 
-	return feedbacks
+	self.setFeedbackDefinitions(feedbacks)
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
 	"devDependencies": {
 		"@companion-module/tools": "^1.5.1"
 	},
-	"prettier": "@companion-module/tools/.prettierrc.json"
+	"prettier": "@companion-module/tools/.prettierrc.json",
+	"packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/presets.js
+++ b/presets.js
@@ -1,6 +1,6 @@
 import { combineRgb } from '@companion-module/base'
 
-export function getPresets() {
+export default function (self) {
 	const ColorWhite = combineRgb(255, 255, 255)
 	const ColorBlack = combineRgb(0, 0, 0)
 	const ColorRed = combineRgb(200, 0, 0)
@@ -9,8 +9,7 @@ export function getPresets() {
 
 	let presets = {}
 
-	if (this.switch.poePortConfig) {
-		this.switch.poePortConfig.forEach((port) => {
+		self.poe_status.all().forEach((port) => {
 			presets[`poe_${port.portid}`] = {
 				type: 'button',
 				category: 'POE',
@@ -49,11 +48,9 @@ export function getPresets() {
 				],
 			}
 		})
-	}
 
-	if (this.switch.switchStatsPort) {
-		this.switch.switchStatsPort.forEach((port) => {
-			presets[`poe_${port.portId}`] = {
+		self.port_stats.all().forEach((port) => {
+			presets[`link_${port.portId}`] = {
 				type: 'button',
 				category: 'Link Status',
 				name: `Link Status Port ${port.portId}`,
@@ -83,7 +80,6 @@ export function getPresets() {
 				],
 			}
 		})
-	}
 
-	return presets
+	self.setPresetDefinitions(presets)
 }

--- a/switch.js
+++ b/switch.js
@@ -1,0 +1,330 @@
+import fetch from 'node-fetch'
+import https from 'https'
+
+class NetgearM4250 {
+	constructor(url_or_ip_address, username, password) {
+		this.url_or_ip_address = url_or_ip_address
+		this.username = username
+		this.password = password
+		this.token = null
+
+		this.httpsAgent = new https.Agent({
+			rejectUnauthorized: false,
+		})
+	}
+
+	async login() {
+		const request = new LoginRequest(this.httpsAgent)
+		const data = await request.fetch(this.url_or_ip_address, this.username, this.password)
+
+		if (data.resp.status === 'success') {
+			this.token = data.login.token
+		} else {
+			console.error(data.resp.respMsg)
+			throw new Error(data.resp.respMsg)
+		}
+
+		this.loginExpiresAt = Date.now() + parseInt(data.login.expire) * 1000
+
+		return true
+	}
+
+	/**
+	 * Enable POE on a list of ports
+	 * @param {number[]} ports - The ports to enable POE for
+	 */
+	async enable_poe_ports(ports) {
+		const request = new POEStateChangeRequest(true, this.httpsAgent, this.token)
+
+		const map = await this.get_port_poe_status()
+
+		for (const port of ports) {
+			await request.fetch(this.url_or_ip_address, port, map.get_port_configuration(port))
+			console.log(`Enabled port ${port}`)
+		}
+	}
+
+	/**
+	 * Disable POE on a list of ports
+	 * @param {number[]} ports - The ports to disable POE for
+	 */
+	async disable_poe_ports(ports) {
+		const request = new POEStateChangeRequest(false, this.httpsAgent, this.token)
+
+		const map = await this.get_port_poe_status()
+
+		for (const port of ports) {
+			await request.fetch(this.url_or_ip_address, port, map.get_port_configuration(port))
+			console.log(`Disabled port ${port}`)
+		}
+	}
+
+	/**
+	 * Toggle POE on a list of ports
+	 * @param {number[]} ports - The ports to toggle POE for
+	 */
+	async toggle_poe_ports(ports) {
+		const status = await this.get_port_poe_status()
+
+		for (const port of ports) {
+			const port_config = status.get_port_configuration(port)
+			if (port_config.enable) {
+				await this.disable_poe_ports([port])
+			} else {
+				await this.enable_poe_ports([port])
+			}
+		}
+	}
+
+	/**
+	 * Power cycle POE on a list of ports
+	 * @param {number[]} ports - The ports to power cycle POE for
+	 */
+	async power_cycle_poe_ports(ports) {
+		const request = new PoePowerCycleRequest(this.httpsAgent, this.token)
+		const map = await this.get_port_poe_status()
+		for (const port of ports) {
+			await request.fetch(this.url_or_ip_address, port, map.get_port_configuration(port))
+		}
+	}
+
+	async power_cycle_switch() {
+		console.log('Power cycling switch')
+		const request = new SwitchPowerCycleRequest(this.httpsAgent, this.token)
+		const response = await request.fetch(this.url_or_ip_address)
+		console.log(response)
+	}
+
+	async get_port_poe_status() {
+		const request = new POEConfigRequest(this.httpsAgent, this.token)
+		return await request.fetch(this.url_or_ip_address)
+	}
+
+	async port_has_link(port_number) {
+		const stats = await this.get_port_stats()
+		const port = stats.get_port_stats(port_number)
+		// `130` is a magic number for "unknown" speed (ie – the link is down)
+		return port.speed !== 130
+	}
+
+	async get_port_stats() {
+		const request = new PortStatsRequest(this.httpsAgent, this.token)
+		return await request.fetch(this.url_or_ip_address)
+	}
+
+	async get_device_name() {
+		const response = await fetch(`https://${this.url_or_ip_address}:8443/api/v1/device_name`, {
+			method: 'GET',
+			agent: this.httpsAgent,
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+			},
+		})
+		const json = await response.json()
+		return json.deviceName.name
+	}
+
+	async get_device_status() {
+		const response = await fetch(`https://${this.url_or_ip_address}:8443/api/v1/device_info`, {
+			method: 'GET',
+			agent: this.httpsAgent,
+			headers: {
+				Authorization: `Bearer ${this.token}`,
+			},
+		})
+
+		const json = await response.json()
+		return json.deviceInfo
+	}
+}
+
+class POEStateChangeRequest {
+	constructor(enable, httpsAgent, token) {
+		this.enable = enable
+		this.agent = httpsAgent
+		this.headers = {
+			Authorization: `Bearer ${token}`,
+		}
+	}
+
+	async fetch(url_or_ip_address, port, config) {
+		delete config.portid
+		config.enable = this.enable
+
+		return await fetch(`https://${url_or_ip_address}:8443/api/v1/swcfg_poe?portid=${port}`, {
+			method: 'POST',
+			agent: this.agent,
+			headers: this.headers,
+			body: JSON.stringify({
+				poePortConfig: config,
+			}),
+		})
+	}
+}
+
+class PoePowerCycleRequest {
+	constructor(httpsAgent, token) {
+		this.agent = httpsAgent
+		this.headers = {
+			Accept: 'application/json',
+			Authorization: `Bearer ${token}`,
+		}
+	}
+
+	async fetch(url_or_ip_address, port, config) {
+		delete config.portid
+		config.reset = true
+
+		return await fetch(`https://${url_or_ip_address}:8443/api/v1/swcfg_poe?portid=${port}`, {
+			method: 'POST',
+			agent: this.agent,
+			headers: this.headers,
+			body: JSON.stringify({
+				poePortConfig: config,
+			}),
+		})
+	}
+}
+
+class POEConfigRequest {
+	constructor(httpsAgent, token) {
+		this.agent = httpsAgent
+		this.headers = {
+			Accept: 'application/json',
+			Authorization: `Bearer ${token}`,
+		}
+	}
+
+	async fetch(url_or_ip_address) {
+		const response = await fetch(`https://${url_or_ip_address}:8443/api/v1/swcfg_poe?portid=ALL`, {
+			method: 'GET',
+			agent: this.agent,
+			headers: this.headers,
+			redirect: 'follow', // TODO: Need this?
+		})
+
+		return new PortPoeConfigurationMap(await response.json())
+	}
+}
+
+class LoginRequest {
+	constructor(httpsAgent) {
+		this.agent = httpsAgent
+	}
+
+	async fetch(url_or_ip_address, username, password) {
+		const body = {
+			login: {
+				username: username,
+				password: password,
+			},
+		}
+
+		const response = await fetch(`https://${url_or_ip_address}:8443/api/v1/login`, {
+			method: 'POST',
+			agent: this.agent,
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(body),
+		})
+
+		const responseBody = await response.text()
+
+		try {
+			return JSON.parse(responseBody)
+		} catch (error) {
+			console.error(responseBody)
+			throw new Error(responseBody)
+		}
+	}
+}
+
+class PortStatsRequest {
+	constructor(httpsAgent, token) {
+		this.agent = httpsAgent
+		this.headers = {
+			Accept: 'application/json',
+			Authorization: `Bearer ${token}`,
+		}
+	}
+
+	async fetch(url_or_ip_address) {
+		const response = await fetch(`https://${url_or_ip_address}:8443/api/v1/sw_portstats?portid=ALL`, {
+			method: 'GET',
+			agent: this.agent,
+			headers: this.headers,
+		})
+
+		return new PortStatsMap(await response.json())
+	}
+}
+
+class SwitchPowerCycleRequest {
+	constructor(httpsAgent, token) {
+		this.agent = httpsAgent
+		this.headers = {
+			Accept: 'application/json',
+			Authorization: `Bearer ${token}`,
+		}
+	}
+
+	async fetch(url_or_ip_address) {
+		const body = {
+			deviceReboot: {
+				afterSecs: 2,
+			},
+		}
+
+		const response = await fetch(`https://${url_or_ip_address}:8443/api/v1/device_reboot`, {
+			method: 'POST',
+			agent: this.agent,
+			headers: this.headers,
+			body: JSON.stringify(body),
+		})
+
+		const json = await response.json()
+		console.log(json)
+
+		return json.resp
+	}
+}
+
+class PortPoeConfigurationMap {
+	constructor(data) {
+		this.data = data
+	}
+
+	all() {
+		return this.data.poePortConfig
+	}
+
+	has(port_id) {
+		return this.all().some((item) => item.portid === port_id)
+	}
+
+	get_port_configuration(port_id) {
+		return this.all().find((item) => item.portid === port_id)
+	}
+}
+
+class PortStatsMap {
+	constructor(data) {
+		this.data = data
+	}
+
+	all() {
+		return this.data.switchStatsPort
+	}
+
+	has(port_id) {
+		return this.all().some((item) => item.portId === port_id)
+	}
+
+	get_port_stats(port_id) {
+		return this.all().find((item) => item.portId === port_id)
+	}
+}
+
+export { NetgearM4250 }

--- a/variables.js
+++ b/variables.js
@@ -1,4 +1,4 @@
-export function getVariables() {
+export default function (self) {
 	const variables = []
 
 	variables.push({
@@ -20,8 +20,8 @@ export function getVariables() {
 		name: 'Uptime',
 		variableId: 'uptime',
 	})
-	if (this.switch.switchStatsPort) {
-		this.switch.switchStatsPort.forEach((port) => {
+	if (self.port_stats) {
+		self.port_stats.all().forEach((port) => {
 			let id = port.portId
 			variables.push({
 				name: `Port ${id} - Speed`,
@@ -33,8 +33,8 @@ export function getVariables() {
 			})
 		})
 	}
-	if (this.switch.poePortConfig) {
-		this.switch.poePortConfig.forEach((port) => {
+	if (self.poe_status) {
+		self.poe_status.all().forEach((port) => {
 			let id = port.portid
 			variables.push({
 				name: `Port ${id} - POE Status`,
@@ -46,5 +46,5 @@ export function getVariables() {
 			})
 		})
 	}
-	return variables
+	self.setVariableDefinitions(variables)
 }


### PR DESCRIPTION
Addresses #25.

This PR has two main changes:

1. Moves as much of the code use async/await as possible, making the control flow and parallelism easier to follow.
2. Moves switch communication code into its own file, which removes a ton of code from `main.js`. The storage stuff has abstractions over the underlying data to fetch port data without needing to remember `portid` vs `portId`. I considered refactoring variable and preset registration using generators to solve the problem, but it would've been a big diff for no a lot of benefit.


Tested against a 24 and 48-port 4250

